### PR TITLE
Read FPS in other way when is zero

### DIFF
--- a/vlc_media_list_player.cpp
+++ b/vlc_media_list_player.cpp
@@ -28,7 +28,7 @@
 using namespace vlc;
 
 media_list_player::media_list_player()
-    : _media_list( nullptr ), _media_list_player( nullptr )
+    : _media_list( nullptr ), _media_list_player( nullptr ), _mode( mode_normal )
 {
 }
 
@@ -80,6 +80,7 @@ bool media_list_player::open( libvlc_instance_t* inst )
     if( _media_list_player ) {
         libvlc_media_list_player_set_media_list( _media_list_player, _media_list );
         libvlc_media_list_player_set_media_player( _media_list_player, get_mp() );
+        set_playback_mode( _mode );
         return true;
     }
 
@@ -149,7 +150,8 @@ void media_list_player::set_playback_mode( playback_mode_e m )
     }
 
     _mode = m;
-    libvlc_media_list_player_set_playback_mode( _media_list_player, libvlcMode );
+    if(_media_list_player)
+        libvlc_media_list_player_set_playback_mode( _media_list_player, libvlcMode );
 }
 
 int media_list_player::add_media( const vlc::media& media )

--- a/vlc_playback.cpp
+++ b/vlc_playback.cpp
@@ -99,5 +99,21 @@ float playback::get_fps()
     if( !_player.is_open() )
         return 0;
 
-    return libvlc_media_player_get_fps( _player.get_mp() );
+    float fps = libvlc_media_player_get_fps( _player.get_mp() );
+    if( fps <= 0.0f ) {
+        libvlc_media_track_t** tracks = nullptr;
+        libvlc_media_t* media = libvlc_media_player_get_media( _player.get_mp() );
+        libvlc_media_parse( media );
+
+        int nTracks = libvlc_media_tracks_get( media, &tracks );
+        for( int i = 0; i < nTracks; ++i ) {
+            const libvlc_media_track_t* track = tracks[i];
+            if( libvlc_track_video == track->i_type && track->video->i_frame_rate_den > 0 ) {
+                fps = track->video->i_frame_rate_num / static_cast<float>(track->video->i_frame_rate_den);
+                break;
+            }
+        }
+    }
+
+    return fps;
 }


### PR DESCRIPTION
`libvlc_media_player_get_fps` returns 0 on some formats, and we need it to compute which frame we're processing. So we get it using `libvlc_media_track_t` struct info.