### PR TITLE
Update LibVLC to 2.2.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libvlc-sdk"]
 	path = libvlc-sdk
-	url = https://github.com/RSATom/libvlc-sdk.git
+	url = https://github.com/metrica-sports/libvlc-sdk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ if( MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8 )
 else()
     find_library( LIBVLC_LIBRARY NAMES vlc libvlc
         HINTS "$ENV{LIBVLC_LIBRARY_PATH}"
+              "${CMAKE_CURRENT_SOURCE_DIR}/libvlc-sdk/lib/macos/"
               "${CMAKE_CURRENT_SOURCE_DIR}/libvlc-sdk/lib/msvc/"
-        PATHS  "/Applications/VLC.app/Contents/MacOS/lib"
         )
 endif()
 


### PR DESCRIPTION
In this pull request, we've updated LibVLC-SDK submodule to not having any external installation requirement or version conflict when compiling on MacOS.